### PR TITLE
Add custom fund rules URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "watch:scripts": "npm run build -- --watch",
     "build:styles": "cpx ./src/*.scss ./dist",
     "build": "npm run build:scripts",
-    "test": "mocha --compilers js:babel-register --require ./dist/_.test.js ./dist",
+    "test": "mocha --compilers js:babel-register --watch-extensions js,jsx src/_.test.js 'src/**/*.test.@(js|jsx)'",
     "precommit": "npm run clean && npm run lint && npm run build && npm run test",
     "prepublish": "npm run precommit"
   }

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,8 +1,10 @@
-import React from 'react';
+import React, {PropTypes} from 'react';
 
 export default class FooterSmall extends React.Component {
   render() {
     let currentYear = new Date().getFullYear();
+    const fundRulesUrl = this.props.fundRulesUrl || 'https://www.nib.com.au/health-information/content/assets/pdf/nib-fund-rules.pdf';
+
     return (
       <footer className="nib-footer nib-footer--small">
         <div className="nib-footer__body">
@@ -14,7 +16,7 @@ export default class FooterSmall extends React.Component {
             </div>
 
             <nav id="ga-footer-copyright-links" className="nib-footer__copyright-links">
-              <a className="nib-footer__copyright-link" id="ga-footer-fund-rules" href="https://www.nib.com.au/health-information/content/assets/pdf/nib-fund-rules.pdf">Fund Rules</a>
+              <a className="nib-footer__copyright-link" id="ga-footer-fund-rules" href={fundRulesUrl}>Fund Rules</a>
               <a className="nib-footer__copyright-link" id="ga-footer-terms" href="https://www.nib.com.au/legal/terms-and-conditions">Terms &amp; Conditions</a>
               <a className="nib-footer__copyright-link" id="ga-footer-privacy" href="https://www.nib.com.au/legal/privacy-policy">Privacy Policy</a>
               <a className="nib-footer__copyright-link" id="ga-footer-code-conduct" href="https://www.nib.com.au/legal#codeofconduct">Code of Conduct</a>
@@ -29,3 +31,7 @@ export default class FooterSmall extends React.Component {
   );
   }
 }
+
+FooterSmall.propTypes = {
+  fundRulesUrl: PropTypes.string
+};

--- a/src/index.test.jsx
+++ b/src/index.test.jsx
@@ -1,3 +1,14 @@
+import React from 'react';
+import Footer from './index.jsx';
 
 describe('<FooterSmall/>', () => {
+  it('should use the default fund rules URL if custom fund rules URL is unspecified', () => {
+    const footer = $(render(<Footer/>).element);
+    expect(footer.find('#ga-footer-fund-rules')[0].node.props.href).to.eql('https://www.nib.com.au/health-information/content/assets/pdf/nib-fund-rules.pdf');
+  });
+
+  it('should use the specified custom fund rules URL if provided', () => {
+    const footer = $(render(<Footer fundRulesUrl="http://some.url/sample.pdf"/>).element);
+    expect(footer.find('#ga-footer-fund-rules')[0].node.props.href).to.eql('http://some.url/sample.pdf');
+  });
 });


### PR DESCRIPTION
These changes enable a custom fund rules URL to be supplied. When it is not specified, the default URL will be used.
